### PR TITLE
Update tpm2net.c: Added support for "multiple block" frames

### DIFF
--- a/user/input_protocols/artnet.c
+++ b/user/input_protocols/artnet.c
@@ -12,6 +12,7 @@
 #include <config/config.h>
 
 #include "../output_protocols/ws2801.h"
+#include "../output_protocols/ws2812.h"
 
 #define ARTNET_Port 0x1936
 
@@ -43,7 +44,11 @@ static void ICACHE_FLASH_ATTR artnet_recv_opoutput(unsigned char *packet, unsign
 				uint16_t Length = ((uint16_t)packet[6] << 8) | packet[7];
 				if (packetlen >= 8 + Length) {
 					uint8_t *data = &packet[8];
+#ifdef ENABLE_WS2812
+					ws2812_strip(data,Length);
+#else
 					ws2801_strip(data,Length);
+#endif
 				}
 			} else {
 				//Not intended for us...

--- a/user/input_protocols/tpm2net.c
+++ b/user/input_protocols/tpm2net.c
@@ -12,24 +12,33 @@
 
 #include "../output_protocols/ws2801.h"
 
+uint16_t framebuffer_len = 0;
+unsigned char framebuffer[1536]; //max 512 rgb pixels
+
 static void ICACHE_FLASH_ATTR tpm2net_recv(void *arg, char *pusrdata, unsigned short length) {
-	unsigned char *data =(unsigned char *)pusrdata;
-	if (data && length>=6 && data[0]==0x9C) {
-		uint8_t blocktype = data[1];
-		uint16_t framelength = ((uint16_t)data[2] << 8) | (uint16_t)data[3];
-		uint8_t packagenum = data[4];
-		uint8_t numpackages = data[5];
-		if (length >= framelength + 7 && data[6+framelength]==0x36) {
-			unsigned char *frame = &data[6];
-			if (blocktype == 0xDA) {
-				ws2801_strip(frame,framelength);
-			}
-		} else {
-			//Invalid length or invalid end byte
-		}
-	} else {
-		//Not a valid header
-	}
+    unsigned char *data =(unsigned char *)pusrdata; //pointer to espconn's returned data
+    if (data && length >= 6 && data[0]==0x9C) { // header identifier (packet start)
+        uint8_t blocktype = data[1]; // block type
+        uint16_t framelength = ((uint16_t)data[2] << 8) | (uint16_t)data[3]; // frame length
+        uint8_t packagenum = data[4]; // packet number 0-255 (0x00 = no split)
+        uint8_t numpackages = data[5]; // total packets 1-255
+        if (blocktype == 0xDA) { // data command ...
+            if (length >= framelength + 7 && data[6+framelength]==0x36) { // header end (packet stop)
+                if (packagenum == 0x01 && numpackages == 0x01) { // no frame split found
+                    unsigned char *frame = &data[6]; // pointer 'frame' to espconn's data (start of data)
+                    ws2801_strip(frame, framelength); // send data to strip
+                } else { //frame split is found
+                    os_memcpy (&framebuffer[framebuffer_len], &data[6], framelength);
+                    framebuffer_len += framelength;
+                    if (packagenum == numpackages) { // all packets found 
+                        unsigned char *frame = &framebuffer[0]; // pointer 'frame' framebuffer
+                        ws2801_strip(frame, framebuffer_len); // send data to strip
+                        framebuffer_len = 0;
+                    }
+                }
+            }
+        }
+    }
 }
 
 void tpm2net_init() {

--- a/user/input_protocols/tpm2net.c
+++ b/user/input_protocols/tpm2net.c
@@ -11,6 +11,7 @@
 #include "espconn.h"
 
 #include "../output_protocols/ws2801.h"
+#include "../output_protocols/ws2812.h"
 
 uint16_t framebuffer_len = 0;
 unsigned char framebuffer[1536]; //max 512 rgb pixels
@@ -26,13 +27,21 @@ static void ICACHE_FLASH_ATTR tpm2net_recv(void *arg, char *pusrdata, unsigned s
             if (length >= framelength + 7 && data[6+framelength]==0x36) { // header end (packet stop)
                 if (numpackages == 0x01) { // no frame split found
                     unsigned char *frame = &data[6]; // pointer 'frame' to espconn's data (start of data)
+#ifdef ENABLE_WS2812
+                    ws2812_strip(frame, framelength); // send data to strip
+#else
                     ws2801_strip(frame, framelength); // send data to strip
+#endif
                 } else { //frame split is found
                     os_memcpy (&framebuffer[framebuffer_len], &data[6], framelength);
                     framebuffer_len += framelength;
                     if (packagenum == numpackages) { // all packets found 
                         unsigned char *frame = &framebuffer[0]; // pointer 'frame' framebuffer
+#ifdef ENABLE_WS2812
+                        ws2812_strip(frame, framebuffer_len); // send data to strip
+#else
                         ws2801_strip(frame, framebuffer_len); // send data to strip
+#endif
                         framebuffer_len = 0;
                     }
                 }

--- a/user/input_protocols/tpm2net.c
+++ b/user/input_protocols/tpm2net.c
@@ -24,7 +24,7 @@ static void ICACHE_FLASH_ATTR tpm2net_recv(void *arg, char *pusrdata, unsigned s
         uint8_t numpackages = data[5]; // total packets 1-255
         if (blocktype == 0xDA) { // data command ...
             if (length >= framelength + 7 && data[6+framelength]==0x36) { // header end (packet stop)
-                if (packagenum == 0x01 && numpackages == 0x01) { // no frame split found
+                if (numpackages == 0x01) { // no frame split found
                     unsigned char *frame = &data[6]; // pointer 'frame' to espconn's data (start of data)
                     ws2801_strip(frame, framelength); // send data to strip
                 } else { //frame split is found

--- a/user/main.c
+++ b/user/main.c
@@ -15,8 +15,8 @@
 #include "user_interface.h"
 #include "espconn.h"
 #include "mem.h"
-
 #include "output_protocols/ws2801.h"
+#include "output_protocols/ws2812.h"
 #include "input_protocols/artnet.h"
 #include "input_protocols/tpm2net.h"
 #include "config/httpd.h"
@@ -84,9 +84,11 @@ user_init()
 
 	wifi_station_set_config(&stconf);
 	wifi_station_set_auto_connect(1);
-
-    ws2801_init();
-
+#ifdef ENABLE_WS2812
+	ws2812_init();
+#else
+	ws2801_init();
+#endif
     //Wait for system to be done.
     system_init_done_cb(&system_is_done);
     //system_os_task()

--- a/user/output_protocols/ws2812.c
+++ b/user/output_protocols/ws2812.c
@@ -1,0 +1,43 @@
+#include "ws2812.h"
+#include "osapi.h"
+
+void ICACHE_FLASH_ATTR SEND_WS_0()
+{
+	uint8_t time;
+	time = 4; while(time--) WRITE_PERI_REG( PERIPHS_GPIO_BASEADDR + GPIO_ID_PIN(WSGPIO), 1 );
+	time = 9; while(time--) WRITE_PERI_REG( PERIPHS_GPIO_BASEADDR + GPIO_ID_PIN(WSGPIO), 0 );
+}
+
+void ICACHE_FLASH_ATTR SEND_WS_1()
+{
+	uint8_t time; 
+	time = 8; while(time--) WRITE_PERI_REG( PERIPHS_GPIO_BASEADDR + GPIO_ID_PIN(WSGPIO), 1 );
+	time = 6; while(time--) WRITE_PERI_REG( PERIPHS_GPIO_BASEADDR + GPIO_ID_PIN(WSGPIO), 0 );
+}
+
+void ICACHE_FLASH_ATTR ws2812_strip( uint8_t * buffer, uint16_t length )
+{
+	uint16_t i;
+	GPIO_OUTPUT_SET(GPIO_ID_PIN(WSGPIO), 0);
+
+	os_intr_lock();
+	for( i = 0; i < length; i++ )
+	{
+		uint8_t mask = 0x80;
+		uint8_t byte = buffer[i];
+		while (mask) 
+		{
+			( byte & mask ) ? SEND_WS_1() : SEND_WS_0();
+			mask >>= 1;
+        	}
+	}
+	os_intr_unlock();
+}
+
+void ICACHE_FLASH_ATTR ws2812_init()
+{
+	ets_wdt_disable();
+	char outbuffer[] = { 0x00, 0x00, 0x00 };
+	ws2812_out( outbuffer, sizeof(outbuffer) );
+}
+

--- a/user/output_protocols/ws2812.h
+++ b/user/output_protocols/ws2812.h
@@ -1,0 +1,14 @@
+#ifndef _WS2812_H
+#define _WS2812_H
+
+#define WSGPIO 0
+
+#include "ets_sys.h"
+
+void ICACHE_FLASH_ATTR ws2812_strip( uint8_t * buffer, uint16_t length );
+void ICACHE_FLASH_ATTR ws2812_init();
+
+#define GPIO_OUTPUT_SET(gpio_no, bit_value) gpio_output_set(bit_value<<gpio_no, ((~bit_value)&0x01)<<gpio_no, 1<<gpio_no,0)
+
+#endif
+


### PR DESCRIPTION
The tpm2net protocol supports splitting the data frame over several packets. This is done to avoid network packet fragmentation when the (ie. 512 rgb leds) frame size approches the network mtu. This patch supports tpm2net "multiple block" frames.
